### PR TITLE
Autokool move the h1 to the top

### DIFF
--- a/src/pages/autokool.tsx
+++ b/src/pages/autokool.tsx
@@ -3,8 +3,8 @@ import { StyledLink } from "@/components/StyledLink";
 const Autokool = () => {
   return (
     <>
+      <h1 className="text-3xl">Autokool</h1>
       <section className="grid gap-2">
-        <h1 className="text-3xl">Autokool</h1>
         <p>
           ALFA PRO OÜ-le on Haridus- ja Teadusministeeriumi poolt väljastatud
           tegevusluba mootorsõidukijuhtide koolitamiseks B-kategoorias. Alus:


### PR DESCRIPTION
This is done because of the gap that is included now in the nested div in Layout.